### PR TITLE
PyPI 0.1.0 working CUDA `hello`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# TEMP
-CMakeLists.txt
-
 build
 
 # Prerequisites

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "googletest"]
 	path = googletest
 	url = https://github.com/google/googletest.git
+[submodule "pybind11"]
+	path = pybind11
+	url = https://github.com/pybind/pybind11.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.12)
+project(pybind11_cuda_project)
+
+find_package(CUDA REQUIRED)
+include_directories(${CUDA_INCLUDE_DIRS})
+link_directories(${CUDA_LIBRARY_DIRS})
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+include_directories(${Python3_INCLUDE_DIRS})
+
+add_subdirectory(pybind11)
+include_directories(./pybind11/include)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+
+# Add your source files from the src directory
+set(SOURCE_FILES src/bindings.cpp src/operations.cu src/tensor.hpp) # Add any other files as needed
+
+CUDA_ADD_LIBRARY(tensor SHARED ${SOURCE_FILES})
+target_link_libraries(tensor ${Python3_LIBRARIES} ${CUDA_LIBRARIES} pybind11::module)
+set_target_properties(tensor PROPERTIES PREFIX "")

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include src/tensor.hpp
 include src/operations.cu
+include src/bindings.cpp
+recursive-include pybind11 *

--- a/cudagrad/__init__.py
+++ b/cudagrad/__init__.py
@@ -4,5 +4,6 @@ from cudagrad.nn import Module as Module
 from cudagrad.nn import mse as mse
 from cudagrad.nn import sgd as sgd
 from cudagrad.tensor import Tensor as Tensor
+from cudagrad.tensor import hello as hello
 
-__version__ = "0.0.52"
+__version__ = "0.1.0"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,6 @@
+git submodule update --init --recursive
+rm -rf build
+mkdir build
+cd build
+cmake ..
+make

--- a/install.sh
+++ b/install.sh
@@ -4,3 +4,4 @@ mkdir build
 cd build
 cmake ..
 make
+cp tensor.so ../cudagrad/

--- a/prepublish.sh
+++ b/prepublish.sh
@@ -1,0 +1,6 @@
+rm -rf dist
+python setup.py sdist bdist_wheel
+# TODO fix hardcode version
+cd dist
+pip install cudagrad-0.1.0.tar.gz
+python -c "from cudagrad import hello; hello()"

--- a/project.py
+++ b/project.py
@@ -109,6 +109,11 @@ class Project:
         # FIXME skipping installation 'tests' on github runner for now
         if (str(Path(".").resolve()).split("/")[2]) == "runner":
             return
+        
+        os.chdir("..")
+        RUN("git restore CMakeLists.txt")
+        return
+
         RUN("python -m pip uninstall -y cudagrad")
         RUN("python -m pip cache purge")
         os.chdir(os.path.expanduser("~/cudagrad"))

--- a/project.py
+++ b/project.py
@@ -112,21 +112,16 @@ class Project:
         
         os.chdir("..")
         RUN("git restore CMakeLists.txt")
-        return
 
         RUN("python -m pip uninstall -y cudagrad")
         RUN("python -m pip cache purge")
         os.chdir(os.path.expanduser("~/cudagrad"))
-        RUN("rm CMakeLists.txt")
-        RUN("python -m pip install .")
-        RUN(
-            "cp ./build/lib.macosx-13.2-arm64-cpython-311/cudagrad/tensor.cpython-311-darwin.so ./cudagrad"
-        )
-        RUN("python tests/test_backward.py")
-        os.chdir(os.path.expanduser("~/cudagrad"))
+        RUN("pip install .")
+        # RUN("python tests/test_backward.py")
         RUN("python -m pip install cudagrad")
         RUN("python -m cudagrad.linear")
         RUN("python -m cudagrad.mlp")
+        RUN("python -m cudagrad.moons")
         RUN("git restore cudagrad/plots/*.jpg")
 
     def test_python_3_7(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cudagrad"
-version = "0.0.52"
+version = "0.1.0"
 description = "A tensor-valued autograd engine for Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,58 @@ import toml
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import find_packages, setup
 
+
+import os
+import re
+import subprocess
+import sys
+import platform
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name, sourcedir=''):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+class CMakeBuild(build_ext):
+    def run(self):
+        try:
+            out = subprocess.check_output(['cmake', '--version'])
+        except OSError:
+            raise RuntimeError("CMake must be installed to build the following extensions: " +
+                               ", ".join(e.name for e in self.extensions))
+
+        for ext in self.extensions:
+            self.build_extension(ext)
+
+    def build_extension(self, ext):
+        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+
+        cfg = 'Debug' if self.debug else 'Release'
+        build_args = ['--config', cfg]
+
+        if platform.system() == "Windows":
+            cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
+            if sys.maxsize > 2**32:
+                cmake_args += ['-A', 'x64']
+            build_args += ['--', '/m']
+        else:
+            cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
+            build_args += ['--', '-j2']
+
+        env = os.environ.copy()
+        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
+                                                              self.distribution.get_version())
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
+        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
+
+
 # assert which("nvcc") is not None
 
 
@@ -18,24 +70,6 @@ def get_version_from_toml():
 
 __version__ = get_version_from_toml()
 
-# The main interface is through Pybind11Extension.
-# * You can add cxx_std=11/14/17, and then build_ext can be removed.
-# * You can set include_pybind11=false to add the include directory yourself,
-#   say from a submodule.
-#
-# Note:
-#   Sort input source files if you glob sources to ensure bit-for-bit
-#   reproducible builds (https://github.com/pybind/cudagrad/pull/53)
-
-ext_modules = [
-    Pybind11Extension(
-        "cudagrad.tensor",
-        ["src/bindings.cpp"],
-        # Example: passing in the version to the compiled code
-        define_macros=[("VERSION_INFO", __version__)],
-    ),
-]
-
 setup(
     name="cudagrad",
     version=__version__,
@@ -44,11 +78,11 @@ setup(
     url="https://github.com/cudagrad/cudagrad",
     description="A tensor-valued autograd engine for Python",
     long_description="",
-    ext_modules=ext_modules,
+    ext_modules=[CMakeExtension('cudagrad')],
     # extras_require={"test": "pytest"},
     # Currently, build_ext only provides an optional "highest supported C++
     # level" feature, but in the future it may provide more features.
-    cmdclass={"build_ext": build_ext},
+    cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,
     python_requires=">=3.7",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ from setuptools.command.build_ext import build_ext
 
 from pybind11.setup_helpers import build_ext
 
-
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=''):
         Extension.__init__(self, name, sources=[])
@@ -18,33 +17,28 @@ class CMakeExtension(Extension):
 class CMakeBuild(build_ext):
     def run(self):
         try:
-            subprocess.check_output(['cmake', '--version'])
+            out = subprocess.check_output(['cmake', '--version'])
         except OSError:
-            raise RuntimeError("CMake must be installed to build tensor!")
+            raise RuntimeError("CMake must be installed to build the following extensions: " +
+                               ", ".join(e.name for e in self.extensions))
 
-        for extension in self.extensions:
-            self.build_extension(extension)
+        for ext in self.extensions:
+            self.build_extension(ext)
 
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
                       '-DPYTHON_EXECUTABLE=' + sys.executable]
 
+        cfg = 'Debug' if self.debug else 'Release'
+        build_args = ['--config', cfg]
+
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
-        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args
-                              , cwd=self.build_temp)
-        subprocess.check_call(['cmake', '--build', '.'], cwd=self.build_temp)
 
-        # print("Listing all files in build_temp directory:")
-        # for root, dirs, files in os.walk(self.build_temp):
-        #     for file in files:
-        #         print(os.path.join(root, file))
-
-        built_lib = os.path.join(self.build_temp,'lib', 'tensor.so')
-        dest_lib = os.path.join(self.build_lib, 'cudagrad', 'tensor.so')
-        move(built_lib, dest_lib)
-
+        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp)
+        subprocess.check_call(['cmake', '--build', '.', '--target', ext.name] + build_args, cwd=self.build_temp)
+        subprocess.check_call(['cp', os.path.join(self.build_lib, 'tensor.so'), os.path.join(extdir, 'cudagrad', 'tensor.so')])
 
 def get_version_from_toml():
     data = toml.load("pyproject.toml")
@@ -65,7 +59,7 @@ setup(
     url="https://github.com/cudagrad/cudagrad",
     description="A tensor-valued autograd engine for Python",
     long_description="",
-    ext_modules=[CMakeExtension('cudagrad.tensor')],
+    ext_modules=[CMakeExtension('tensor')],
     cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,
     python_requires=">=3.7",

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -31,13 +31,11 @@ PYBIND11_MODULE(tensor, m) {
         Tensor
     )pbdoc";
 
-#ifdef __CUDACC__
   m.def("hello", &cg::hello, R"pbdoc(
         Can has CUDA?
 
         Hello!
     )pbdoc");
-#endif
 
   py::class_<cg::DataProxy>(m, "_DataProxy")
       .def("__call__", &cg::DataProxy::operator())

--- a/src/operations.cu
+++ b/src/operations.cu
@@ -9,9 +9,13 @@
 
 #include <stdio.h>
 
+namespace cg {
+
 __global__ void helloFromGPU() { printf("Hello, GPU!\n"); }
 
 extern "C" void hello() {
   helloFromGPU<<<1, 1>>>();
   cudaDeviceSynchronize();
 }
+
+} // namespace cg

--- a/src/tensor.hpp
+++ b/src/tensor.hpp
@@ -32,10 +32,7 @@ void UNUSED(Args &&...args) {
 
 namespace cg {
 
-// __CUDACC__ isn't needed now, but maybe more clear
-#ifdef __CUDACC__
 extern "C" void hello();
-#endif
 
 // using using for now in case in the future during operator fusion
 // I need to know what is actually happening, maybe more clear


### PR DESCRIPTION
Working `pip install cudagrad`
```
ryan@Lambda-TensorBook:/$ pip uninstall -y cudagrad
WARNING: Skipping cudagrad as it is not installed.
ryan@Lambda-TensorBook:/$ pip cache purge
Files removed: 1
ryan@Lambda-TensorBook:/$ pip list | grep cudagrad
ryan@Lambda-TensorBook:/$ pip install cudagrad
Defaulting to user installation because normal site-packages is not writeable
Collecting cudagrad
  Downloading cudagrad-0.1.0.tar.gz (785 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 785.5/785.5 KB 3.2 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: cudagrad
  Building wheel for cudagrad (pyproject.toml) ... done
  Created wheel for cudagrad: filename=cudagrad-0.1.0-cp310-cp310-linux_x86_64.whl size=1460323 sha256=d4186f4ec1c282c1ca38dabbc0b1178608d291e22dafacd4c942f8a9b257f4cb
  Stored in directory: /home/ryan/.cache/pip/wheels/e7/c0/7e/f79d8b49b8f2673a52642cea5fd565d560f83fd969db49db0d
Successfully built cudagrad
Installing collected packages: cudagrad
Successfully installed cudagrad-0.1.0
ryan@Lambda-TensorBook:/$ python
Python 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import cudagrad
>>> cudagrad
<module 'cudagrad' from '/home/ryan/.local/lib/python3.10/site-packages/cudagrad/__init__.py'>
>>> cudagrad.tensor.hello()
Hello, GPU!
>>> exit()
ryan@Lambda-TensorBook:/$ cd /home/ryan/.local/lib/python3.10/site-packages/cudagrad
ryan@Lambda-TensorBook:~/.local/lib/python3.10/site-packages/cudagrad$ ls
__init__.py  linear.py  mlp.py  moons.py  nn.py  __pycache__  tensor.so
```

Working preinstall:

```
ryan@Lambda-TensorBook:~/cudagrad$ sh prepublish.sh 
running sdist
running egg_info
writing cudagrad.egg-info/PKG-INFO
writing dependency_links to cudagrad.egg-info/dependency_links.txt
writing top-level names to cudagrad.egg-info/top_level.txt
reading manifest file 'cudagrad.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'cudagrad.egg-info/SOURCES.txt'
running check
creating cudagrad-0.1.0
creating cudagrad-0.1.0/cudagrad
creating cudagrad-0.1.0/cudagrad.egg-info
creating cudagrad-0.1.0/pybind11
creating cudagrad-0.1.0/pybind11/.github
creating cudagrad-0.1.0/pybind11/.github/ISSUE_TEMPLATE
creating cudagrad-0.1.0/pybind11/.github/matchers
creating cudagrad-0.1.0/pybind11/.github/workflows
creating cudagrad-0.1.0/pybind11/docs
creating cudagrad-0.1.0/pybind11/docs/_static
creating cudagrad-0.1.0/pybind11/docs/_static/css
creating cudagrad-0.1.0/pybind11/docs/advanced
creating cudagrad-0.1.0/pybind11/docs/advanced/cast
creating cudagrad-0.1.0/pybind11/docs/advanced/pycpp
creating cudagrad-0.1.0/pybind11/docs/cmake
creating cudagrad-0.1.0/pybind11/include
creating cudagrad-0.1.0/pybind11/include/pybind11
creating cudagrad-0.1.0/pybind11/include/pybind11/detail
creating cudagrad-0.1.0/pybind11/include/pybind11/eigen
creating cudagrad-0.1.0/pybind11/include/pybind11/stl
creating cudagrad-0.1.0/pybind11/pybind11
creating cudagrad-0.1.0/pybind11/tests
creating cudagrad-0.1.0/pybind11/tests/extra_python_package
creating cudagrad-0.1.0/pybind11/tests/extra_setuptools
creating cudagrad-0.1.0/pybind11/tests/test_cmake_build
creating cudagrad-0.1.0/pybind11/tests/test_cmake_build/installed_embed
creating cudagrad-0.1.0/pybind11/tests/test_cmake_build/installed_function
creating cudagrad-0.1.0/pybind11/tests/test_cmake_build/installed_target
creating cudagrad-0.1.0/pybind11/tests/test_cmake_build/subdirectory_embed
creating cudagrad-0.1.0/pybind11/tests/test_cmake_build/subdirectory_function
creating cudagrad-0.1.0/pybind11/tests/test_cmake_build/subdirectory_target
creating cudagrad-0.1.0/pybind11/tests/test_embed
creating cudagrad-0.1.0/pybind11/tools
creating cudagrad-0.1.0/src
copying files to cudagrad-0.1.0...
copying CMakeLists.txt -> cudagrad-0.1.0
copying LICENSE -> cudagrad-0.1.0
copying MANIFEST.in -> cudagrad-0.1.0
copying README.md -> cudagrad-0.1.0
copying pyproject.toml -> cudagrad-0.1.0
copying setup.py -> cudagrad-0.1.0
copying cudagrad/__init__.py -> cudagrad-0.1.0/cudagrad
copying cudagrad/linear.py -> cudagrad-0.1.0/cudagrad
copying cudagrad/mlp.py -> cudagrad-0.1.0/cudagrad
copying cudagrad/moons.py -> cudagrad-0.1.0/cudagrad
copying cudagrad/nn.py -> cudagrad-0.1.0/cudagrad
copying cudagrad.egg-info/PKG-INFO -> cudagrad-0.1.0/cudagrad.egg-info
copying cudagrad.egg-info/SOURCES.txt -> cudagrad-0.1.0/cudagrad.egg-info
copying cudagrad.egg-info/dependency_links.txt -> cudagrad-0.1.0/cudagrad.egg-info
copying cudagrad.egg-info/not-zip-safe -> cudagrad-0.1.0/cudagrad.egg-info
copying cudagrad.egg-info/top_level.txt -> cudagrad-0.1.0/cudagrad.egg-info
copying pybind11/.appveyor.yml -> cudagrad-0.1.0/pybind11
copying pybind11/.clang-format -> cudagrad-0.1.0/pybind11
copying pybind11/.clang-tidy -> cudagrad-0.1.0/pybind11
copying pybind11/.cmake-format.yaml -> cudagrad-0.1.0/pybind11
copying pybind11/.codespell-ignore-lines -> cudagrad-0.1.0/pybind11
copying pybind11/.git -> cudagrad-0.1.0/pybind11
copying pybind11/.gitattributes -> cudagrad-0.1.0/pybind11
copying pybind11/.gitignore -> cudagrad-0.1.0/pybind11
copying pybind11/.pre-commit-config.yaml -> cudagrad-0.1.0/pybind11
copying pybind11/.readthedocs.yml -> cudagrad-0.1.0/pybind11
copying pybind11/CMakeLists.txt -> cudagrad-0.1.0/pybind11
copying pybind11/LICENSE -> cudagrad-0.1.0/pybind11
copying pybind11/MANIFEST.in -> cudagrad-0.1.0/pybind11
copying pybind11/README.rst -> cudagrad-0.1.0/pybind11
copying pybind11/SECURITY.md -> cudagrad-0.1.0/pybind11
copying pybind11/noxfile.py -> cudagrad-0.1.0/pybind11
copying pybind11/pyproject.toml -> cudagrad-0.1.0/pybind11
copying pybind11/setup.cfg -> cudagrad-0.1.0/pybind11
copying pybind11/setup.py -> cudagrad-0.1.0/pybind11
copying pybind11/.github/CODEOWNERS -> cudagrad-0.1.0/pybind11/.github
copying pybind11/.github/CONTRIBUTING.md -> cudagrad-0.1.0/pybind11/.github
copying pybind11/.github/dependabot.yml -> cudagrad-0.1.0/pybind11/.github
copying pybind11/.github/labeler.yml -> cudagrad-0.1.0/pybind11/.github
copying pybind11/.github/labeler_merged.yml -> cudagrad-0.1.0/pybind11/.github
copying pybind11/.github/pull_request_template.md -> cudagrad-0.1.0/pybind11/.github
copying pybind11/.github/ISSUE_TEMPLATE/bug-report.yml -> cudagrad-0.1.0/pybind11/.github/ISSUE_TEMPLATE
copying pybind11/.github/ISSUE_TEMPLATE/config.yml -> cudagrad-0.1.0/pybind11/.github/ISSUE_TEMPLATE
copying pybind11/.github/matchers/pylint.json -> cudagrad-0.1.0/pybind11/.github/matchers
copying pybind11/.github/workflows/ci.yml -> cudagrad-0.1.0/pybind11/.github/workflows
copying pybind11/.github/workflows/configure.yml -> cudagrad-0.1.0/pybind11/.github/workflows
copying pybind11/.github/workflows/format.yml -> cudagrad-0.1.0/pybind11/.github/workflows
copying pybind11/.github/workflows/labeler.yml -> cudagrad-0.1.0/pybind11/.github/workflows
copying pybind11/.github/workflows/pip.yml -> cudagrad-0.1.0/pybind11/.github/workflows
copying pybind11/.github/workflows/upstream.yml -> cudagrad-0.1.0/pybind11/.github/workflows
copying pybind11/docs/Doxyfile -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/Makefile -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/basics.rst -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/benchmark.py -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/benchmark.rst -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/changelog.rst -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/classes.rst -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/compiling.rst -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/conf.py -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/faq.rst -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/index.rst -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/installing.rst -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/limitations.rst -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/pybind11-logo.png -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/pybind11_vs_boost_python1.png -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/pybind11_vs_boost_python1.svg -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/pybind11_vs_boost_python2.png -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/pybind11_vs_boost_python2.svg -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/reference.rst -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/release.rst -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/requirements.txt -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/upgrade.rst -> cudagrad-0.1.0/pybind11/docs
copying pybind11/docs/_static/css/custom.css -> cudagrad-0.1.0/pybind11/docs/_static/css
copying pybind11/docs/advanced/classes.rst -> cudagrad-0.1.0/pybind11/docs/advanced
copying pybind11/docs/advanced/embedding.rst -> cudagrad-0.1.0/pybind11/docs/advanced
copying pybind11/docs/advanced/exceptions.rst -> cudagrad-0.1.0/pybind11/docs/advanced
copying pybind11/docs/advanced/functions.rst -> cudagrad-0.1.0/pybind11/docs/advanced
copying pybind11/docs/advanced/misc.rst -> cudagrad-0.1.0/pybind11/docs/advanced
copying pybind11/docs/advanced/smart_ptrs.rst -> cudagrad-0.1.0/pybind11/docs/advanced
copying pybind11/docs/advanced/cast/chrono.rst -> cudagrad-0.1.0/pybind11/docs/advanced/cast
copying pybind11/docs/advanced/cast/custom.rst -> cudagrad-0.1.0/pybind11/docs/advanced/cast
copying pybind11/docs/advanced/cast/eigen.rst -> cudagrad-0.1.0/pybind11/docs/advanced/cast
copying pybind11/docs/advanced/cast/functional.rst -> cudagrad-0.1.0/pybind11/docs/advanced/cast
copying pybind11/docs/advanced/cast/index.rst -> cudagrad-0.1.0/pybind11/docs/advanced/cast
copying pybind11/docs/advanced/cast/overview.rst -> cudagrad-0.1.0/pybind11/docs/advanced/cast
copying pybind11/docs/advanced/cast/stl.rst -> cudagrad-0.1.0/pybind11/docs/advanced/cast
copying pybind11/docs/advanced/cast/strings.rst -> cudagrad-0.1.0/pybind11/docs/advanced/cast
copying pybind11/docs/advanced/pycpp/index.rst -> cudagrad-0.1.0/pybind11/docs/advanced/pycpp
copying pybind11/docs/advanced/pycpp/numpy.rst -> cudagrad-0.1.0/pybind11/docs/advanced/pycpp
copying pybind11/docs/advanced/pycpp/object.rst -> cudagrad-0.1.0/pybind11/docs/advanced/pycpp
copying pybind11/docs/advanced/pycpp/utilities.rst -> cudagrad-0.1.0/pybind11/docs/advanced/pycpp
copying pybind11/docs/cmake/index.rst -> cudagrad-0.1.0/pybind11/docs/cmake
copying pybind11/include/pybind11/attr.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/buffer_info.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/cast.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/chrono.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/common.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/complex.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/eigen.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/embed.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/eval.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/functional.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/gil.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/gil_safe_call_once.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/iostream.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/numpy.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/operators.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/options.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/pybind11.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/pytypes.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/stl.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/stl_bind.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/type_caster_pyobject_ptr.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/typing.h -> cudagrad-0.1.0/pybind11/include/pybind11
copying pybind11/include/pybind11/detail/class.h -> cudagrad-0.1.0/pybind11/include/pybind11/detail
copying pybind11/include/pybind11/detail/common.h -> cudagrad-0.1.0/pybind11/include/pybind11/detail
copying pybind11/include/pybind11/detail/descr.h -> cudagrad-0.1.0/pybind11/include/pybind11/detail
copying pybind11/include/pybind11/detail/init.h -> cudagrad-0.1.0/pybind11/include/pybind11/detail
copying pybind11/include/pybind11/detail/internals.h -> cudagrad-0.1.0/pybind11/include/pybind11/detail
copying pybind11/include/pybind11/detail/type_caster_base.h -> cudagrad-0.1.0/pybind11/include/pybind11/detail
copying pybind11/include/pybind11/detail/typeid.h -> cudagrad-0.1.0/pybind11/include/pybind11/detail
copying pybind11/include/pybind11/eigen/common.h -> cudagrad-0.1.0/pybind11/include/pybind11/eigen
copying pybind11/include/pybind11/eigen/matrix.h -> cudagrad-0.1.0/pybind11/include/pybind11/eigen
copying pybind11/include/pybind11/eigen/tensor.h -> cudagrad-0.1.0/pybind11/include/pybind11/eigen
copying pybind11/include/pybind11/stl/filesystem.h -> cudagrad-0.1.0/pybind11/include/pybind11/stl
copying pybind11/pybind11/__init__.py -> cudagrad-0.1.0/pybind11/pybind11
copying pybind11/pybind11/__main__.py -> cudagrad-0.1.0/pybind11/pybind11
copying pybind11/pybind11/_version.py -> cudagrad-0.1.0/pybind11/pybind11
copying pybind11/pybind11/commands.py -> cudagrad-0.1.0/pybind11/pybind11
copying pybind11/pybind11/py.typed -> cudagrad-0.1.0/pybind11/pybind11
copying pybind11/pybind11/setup_helpers.py -> cudagrad-0.1.0/pybind11/pybind11
copying pybind11/tests/CMakeLists.txt -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/conftest.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/constructor_stats.h -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/cross_module_gil_utils.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/cross_module_interleaved_error_already_set.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/eigen_tensor_avoid_stl_array.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/env.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/local_bindings.h -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/object.h -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/pybind11_cross_module_tests.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/pybind11_tests.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/pybind11_tests.h -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/pytest.ini -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/requirements.txt -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_async.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_async.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_buffers.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_buffers.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_builtin_casters.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_builtin_casters.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_call_policies.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_call_policies.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_callbacks.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_callbacks.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_chrono.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_chrono.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_class.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_class.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_const_name.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_const_name.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_constants_and_functions.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_constants_and_functions.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_copy_move.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_copy_move.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_custom_type_casters.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_custom_type_casters.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_custom_type_setup.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_custom_type_setup.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_docstring_options.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_docstring_options.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_eigen_matrix.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_eigen_matrix.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_eigen_tensor.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_eigen_tensor.inl -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_eigen_tensor.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_enum.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_enum.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_eval.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_eval.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_eval_call.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_exceptions.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_exceptions.h -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_exceptions.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_factory_constructors.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_factory_constructors.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_gil_scoped.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_gil_scoped.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_iostream.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_iostream.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_kwargs_and_defaults.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_kwargs_and_defaults.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_local_bindings.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_local_bindings.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_methods_and_attributes.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_methods_and_attributes.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_modules.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_modules.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_multiple_inheritance.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_multiple_inheritance.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_numpy_array.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_numpy_array.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_numpy_dtypes.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_numpy_dtypes.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_numpy_vectorize.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_numpy_vectorize.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_opaque_types.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_opaque_types.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_operator_overloading.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_operator_overloading.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_pickling.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_pickling.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_python_multiple_inheritance.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_python_multiple_inheritance.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_pytypes.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_pytypes.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_sequences_and_iterators.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_sequences_and_iterators.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_smart_ptr.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_smart_ptr.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_stl.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_stl.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_stl_binders.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_stl_binders.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_tagbased_polymorphic.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_tagbased_polymorphic.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_thread.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_thread.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_type_caster_pyobject_ptr.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_type_caster_pyobject_ptr.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_union.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_union.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_unnamed_namespace_a.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_unnamed_namespace_a.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_unnamed_namespace_b.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_unnamed_namespace_b.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_vector_unique_ptr_member.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_vector_unique_ptr_member.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_virtual_functions.cpp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/test_virtual_functions.py -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/valgrind-numpy-scipy.supp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/valgrind-python.supp -> cudagrad-0.1.0/pybind11/tests
copying pybind11/tests/extra_python_package/pytest.ini -> cudagrad-0.1.0/pybind11/tests/extra_python_package
copying pybind11/tests/extra_python_package/test_files.py -> cudagrad-0.1.0/pybind11/tests/extra_python_package
copying pybind11/tests/extra_setuptools/pytest.ini -> cudagrad-0.1.0/pybind11/tests/extra_setuptools
copying pybind11/tests/extra_setuptools/test_setuphelper.py -> cudagrad-0.1.0/pybind11/tests/extra_setuptools
copying pybind11/tests/test_cmake_build/CMakeLists.txt -> cudagrad-0.1.0/pybind11/tests/test_cmake_build
copying pybind11/tests/test_cmake_build/embed.cpp -> cudagrad-0.1.0/pybind11/tests/test_cmake_build
copying pybind11/tests/test_cmake_build/main.cpp -> cudagrad-0.1.0/pybind11/tests/test_cmake_build
copying pybind11/tests/test_cmake_build/test.py -> cudagrad-0.1.0/pybind11/tests/test_cmake_build
copying pybind11/tests/test_cmake_build/installed_embed/CMakeLists.txt -> cudagrad-0.1.0/pybind11/tests/test_cmake_build/installed_embed
copying pybind11/tests/test_cmake_build/installed_function/CMakeLists.txt -> cudagrad-0.1.0/pybind11/tests/test_cmake_build/installed_function
copying pybind11/tests/test_cmake_build/installed_target/CMakeLists.txt -> cudagrad-0.1.0/pybind11/tests/test_cmake_build/installed_target
copying pybind11/tests/test_cmake_build/subdirectory_embed/CMakeLists.txt -> cudagrad-0.1.0/pybind11/tests/test_cmake_build/subdirectory_embed
copying pybind11/tests/test_cmake_build/subdirectory_function/CMakeLists.txt -> cudagrad-0.1.0/pybind11/tests/test_cmake_build/subdirectory_function
copying pybind11/tests/test_cmake_build/subdirectory_target/CMakeLists.txt -> cudagrad-0.1.0/pybind11/tests/test_cmake_build/subdirectory_target
copying pybind11/tests/test_embed/CMakeLists.txt -> cudagrad-0.1.0/pybind11/tests/test_embed
copying pybind11/tests/test_embed/catch.cpp -> cudagrad-0.1.0/pybind11/tests/test_embed
copying pybind11/tests/test_embed/external_module.cpp -> cudagrad-0.1.0/pybind11/tests/test_embed
copying pybind11/tests/test_embed/test_interpreter.cpp -> cudagrad-0.1.0/pybind11/tests/test_embed
copying pybind11/tests/test_embed/test_interpreter.py -> cudagrad-0.1.0/pybind11/tests/test_embed
copying pybind11/tests/test_embed/test_trampoline.py -> cudagrad-0.1.0/pybind11/tests/test_embed
copying pybind11/tools/FindCatch.cmake -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/FindEigen3.cmake -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/FindPythonLibsNew.cmake -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/JoinPaths.cmake -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/check-style.sh -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/cmake_uninstall.cmake.in -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/codespell_ignore_lines_from_errors.py -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/libsize.py -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/make_changelog.py -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/pybind11.pc.in -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/pybind11Common.cmake -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/pybind11Config.cmake.in -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/pybind11NewTools.cmake -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/pybind11Tools.cmake -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/pyproject.toml -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/setup_global.py.in -> cudagrad-0.1.0/pybind11/tools
copying pybind11/tools/setup_main.py.in -> cudagrad-0.1.0/pybind11/tools
copying src/bindings.cpp -> cudagrad-0.1.0/src
copying src/operations.cu -> cudagrad-0.1.0/src
copying src/tensor.hpp -> cudagrad-0.1.0/src
Writing cudagrad-0.1.0/setup.cfg
creating dist
Creating tar archive
removing 'cudagrad-0.1.0' (and everything under it)
running bdist_wheel
running build
running build_py
running build_ext
-- pybind11 v2.12.0 dev1
-- Configuring done
-- Generating done
-- Build files have been written to: /home/ryan/cudagrad/build/temp.linux-x86_64-3.10
Consolidate compiler generated dependencies of target tensor
[100%] Built target tensor
/usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
creating build/bdist.linux-x86_64/wheel
copying build/lib.linux-x86_64-3.10/tensor.so -> build/bdist.linux-x86_64/wheel
creating build/bdist.linux-x86_64/wheel/cudagrad
copying build/lib.linux-x86_64-3.10/cudagrad/moons.py -> build/bdist.linux-x86_64/wheel/cudagrad
copying build/lib.linux-x86_64-3.10/cudagrad/tensor.so -> build/bdist.linux-x86_64/wheel/cudagrad
copying build/lib.linux-x86_64-3.10/cudagrad/nn.py -> build/bdist.linux-x86_64/wheel/cudagrad
copying build/lib.linux-x86_64-3.10/cudagrad/__init__.py -> build/bdist.linux-x86_64/wheel/cudagrad
copying build/lib.linux-x86_64-3.10/cudagrad/mlp.py -> build/bdist.linux-x86_64/wheel/cudagrad
copying build/lib.linux-x86_64-3.10/cudagrad/linear.py -> build/bdist.linux-x86_64/wheel/cudagrad
running install_egg_info
Copying cudagrad.egg-info to build/bdist.linux-x86_64/wheel/cudagrad-0.1.0.egg-info
running install_scripts
adding license file "LICENSE" (matched pattern "LICEN[CS]E*")
creating build/bdist.linux-x86_64/wheel/cudagrad-0.1.0.dist-info/WHEEL
creating 'dist/cudagrad-0.1.0-cp310-cp310-linux_x86_64.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'tensor.so'
adding 'cudagrad/__init__.py'
adding 'cudagrad/linear.py'
adding 'cudagrad/mlp.py'
adding 'cudagrad/moons.py'
adding 'cudagrad/nn.py'
adding 'cudagrad/tensor.so'
adding 'cudagrad-0.1.0.dist-info/LICENSE'
adding 'cudagrad-0.1.0.dist-info/METADATA'
adding 'cudagrad-0.1.0.dist-info/WHEEL'
adding 'cudagrad-0.1.0.dist-info/top_level.txt'
adding 'cudagrad-0.1.0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Defaulting to user installation because normal site-packages is not writeable
Processing ./cudagrad-0.1.0.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: cudagrad
  Building wheel for cudagrad (pyproject.toml) ... done
  Created wheel for cudagrad: filename=cudagrad-0.1.0-cp310-cp310-linux_x86_64.whl size=1460070 sha256=60b57cadbc262869464aed62d6b97b8a05aefed5affae44d63b0b5e4f00407d0
  Stored in directory: /home/ryan/.cache/pip/wheels/6a/ad/79/03434684eda6adb913b0d0b178217dcccce74962350a9aa92f
Successfully built cudagrad
Installing collected packages: cudagrad
  Attempting uninstall: cudagrad
    Found existing installation: cudagrad 0.1.0
    Uninstalling cudagrad-0.1.0:
      Successfully uninstalled cudagrad-0.1.0
Successfully installed cudagrad-0.1.0
Hello, GPU!
```